### PR TITLE
Fix reference to rabbitmq in mongodb README.md

### DIFF
--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -27,7 +27,7 @@ This plugin creates the following helper files:
 
 * **devbox.d/mongodb/mongod.conf** - MongoDB configuration file
 * **.devbox/virtenv/mongodb/data** - empty directory for holding your mongodb database
-* **.devbox/virtenv/rabbitmq/process-compose.yaml** - Defines the process to start the MongoDB server
+* **.devbox/virtenv/mongodb/process-compose.yaml** - Defines the process to start the MongoDB server
 
 ## Environment Variables
 


### PR DESCRIPTION
This fixes a copy and paste error.

The README.md still doesn't reflect the directories that are used  but that's a separate issue. https://github.com/jetpack-io/devbox-plugins/issues