### PR TITLE
[monorepo-go] Always download during tidy

### DIFF
--- a/go-monorepo/gotidy.sh
+++ b/go-monorepo/gotidy.sh
@@ -117,12 +117,12 @@ for dir in ${mods}; do
 	echo "gotidy ${dir}: tidying go.mod"
 	go mod tidy
 
+	echo "gotidy ${dir}: downloading dependencies"
+	go mod download
+
 	if [ "${build_flag}" = 1 ]; then
 		echo "gotidy ${dir}: building module"
 		go build ./...
-
-		echo "gotidy ${dir}: downloading dependencies"
-		go mod download
 
 		echo "gotidy ${dir}: building module tests"
 		go test -c -o /dev/null ./...
@@ -137,9 +137,9 @@ done
 export GOWORK=auto
 cd "${repo}"
 go work sync
+go mod download
 
 if [ "${build_flag}" = 1 ]; then
-	go mod download
 
 	for dir in ${mods}; do
 		if ! cd "${dir}"; then


### PR DESCRIPTION
go mod download can have side effects in `go.work.sum` even if dependencies have already been downloaded. We need to always run it.