### PR TITLE
[go-monorepo] add DEVBOX_GO_MONOREPO_EXCLUDE

### DIFF
--- a/go-monorepo/for_each_gomod.sh
+++ b/go-monorepo/for_each_gomod.sh
@@ -3,6 +3,11 @@
 # every module.
 pwd="$(pwd)"
 for dir in $(go list -m -f '{{`{{.Dir}}`}}'); do
+  # Skip directories that match the exclude pattern if set
+  if [ -n "${DEVBOX_GO_MONOREPO_EXCLUDE}" ] && [[ "$dir" =~ ${DEVBOX_GO_MONOREPO_EXCLUDE} ]]; then
+    echo "Skipping excluded directory: $dir"
+    continue
+  fi
   echo "$dir: $*" && cd "$dir" && "$@" || exit $?
 done
 cd "$pwd" || return

--- a/go-monorepo/plugin.json
+++ b/go-monorepo/plugin.json
@@ -25,7 +25,7 @@
       "build": "for_each_gomod go build -v ./...",
       // TODO: fmt and lint is not correctly running on all projects.
       // Some projects need "devbox run fmt" and "devbox run lint".
-      "fmt": "for_each_gomod gofumpt -w -l .",
+      "fmt": "find . -name '*.go' -not -path '*/gen/*' -exec gofumpt -w -l {} \\+",
       "lint": "for_each_gomod golangci-lint run --timeout ${GOLANGCI_LINT_TIMEOUT:-600s}",
       "test": "for_each_gomod go test -race -cover -v ./...",
     }

--- a/go-monorepo/plugin.json
+++ b/go-monorepo/plugin.json
@@ -25,7 +25,7 @@
       "build": "for_each_gomod go build -v ./...",
       // TODO: fmt and lint is not correctly running on all projects.
       // Some projects need "devbox run fmt" and "devbox run lint".
-      "fmt": "find . -name '*.go' -not -path '*/gen/*' -exec gofumpt -w -l {} \\+",
+      "fmt": "for_each_gomod gofumpt -w -l .",
       "lint": "for_each_gomod golangci-lint run --timeout ${GOLANGCI_LINT_TIMEOUT:-600s}",
       "test": "for_each_gomod go test -race -cover -v ./...",
     }


### PR DESCRIPTION
This allows plugin use to exclude directory for build, lint, and test. e.g.

`"DEVBOX_GO_MONOREPO_EXCLUDE": "etudes/*"`