### PR TITLE
Use latest version of golangci-lint and gofumpt

### DIFF
--- a/go-monorepo/plugin.json
+++ b/go-monorepo/plugin.json
@@ -25,7 +25,7 @@
       "build": "for_each_gomod go build -v ./...",
       // TODO: fmt and lint is not correctly running on all projects.
       // Some projects need "devbox run fmt" and "devbox run lint".
-      "fmt": "find . -name '*.go' -not -path '*/gen/*' -exec gofumpt -w -l {} \\+",
+      "fmt": "for_each_gomod golangci-lint fmt --timeout ${GOLANGCI_LINT_TIMEOUT:-600s}",
       "lint": "for_each_gomod golangci-lint run --timeout ${GOLANGCI_LINT_TIMEOUT:-600s}",
       "test": "for_each_gomod go test -race -cover -v ./...",
     }


### PR DESCRIPTION
We were using `runx` to isntall golangci-lint, but, for whatever reason, it's no handling v2 and we've been stuck in v1 for a while. Now that both golangci-lint and gofumpt are in nix packages with pretty recent versions, change to point to those packages.