### PR TITLE
Remove flag from fmt

### DIFF
--- a/go-monorepo/plugin.json
+++ b/go-monorepo/plugin.json
@@ -25,7 +25,7 @@
       "build": "for_each_gomod go build -v ./...",
       // TODO: fmt and lint is not correctly running on all projects.
       // Some projects need "devbox run fmt" and "devbox run lint".
-      "fmt": "for_each_gomod golangci-lint fmt --timeout ${GOLANGCI_LINT_TIMEOUT:-600s}",
+      "fmt": "for_each_gomod golangci-lint fmt",
       "lint": "for_each_gomod golangci-lint run --timeout ${GOLANGCI_LINT_TIMEOUT:-600s}",
       "test": "for_each_gomod go test -race -cover -v ./...",
     }


### PR DESCRIPTION
Remove --timeout flag from `fmt` (it doesn't accept it, it only works for linting)